### PR TITLE
Changed subtypes to match published literature

### DIFF
--- a/src/data/TCGA_ids_and_subtype_glioma.R
+++ b/src/data/TCGA_ids_and_subtype_glioma.R
@@ -1,18 +1,18 @@
 lgr1.cases <-scan("data/raw/cases_LGr1.txt",what="character")
 lgr1.ids <- lgr1.cases[grep("TCGA", lgr1.cases)]
-lgr1.dat <- data.frame(patientid=lgr1.ids, subtype="most upregulate TERT", cancertype="Glioma")
+lgr1.dat <- data.frame(patientid=lgr1.ids, subtype="LGr1", cancertype="Glioma")
 
 lgr2.cases <- scan("data/raw/cases_LGr2.txt",what="character")
 lgr2.ids <- lgr2.cases[grep("TCGA", lgr2.cases)]
-lgr2.dat <- data.frame(patientid=lgr2.ids, subtype="some upregulate TERT", cancertype="Glioma")
+lgr2.dat <- data.frame(patientid=lgr2.ids, subtype="LGr2", cancertype="Glioma")
 
 lgr3.cases <- scan("data/raw/cases_LGr3.txt",what="character")
 lgr3.ids <- lgr3.cases[grep("TCGA", lgr3.cases)]
-lgr3.dat <- data.frame(patientid=lgr3.ids, subtype="TP53 mutations", cancertype="Glioma")
+lgr3.dat <- data.frame(patientid=lgr3.ids, subtype="LGr3", cancertype="Glioma")
 
 lgr4.cases <- scan("data/raw/cases_LGr4.txt", what="character")
 lgr4.ids <- lgr4.cases[grep("TCGA", lgr4.cases)]
-lgr4.dat <- data.frame(patientid=lgr4.ids, subtype="IDH wild-type", cancertype="Glioma")
+lgr4.dat <- data.frame(patientid=lgr4.ids, subtype="LGr4", cancertype="Glioma")
 
 all_glioma <- rbind(lgr1.dat, lgr2.dat, lgr3.dat, lgr4.dat)
 all_glioma[order(all_glioma$patientid), ]

--- a/src/data/TCGA_ids_and_subtype_kirc.R
+++ b/src/data/TCGA_ids_and_subtype_kirc.R
@@ -1,18 +1,18 @@
 m1.cases <- scan("data/raw/cases_m1.txt",what="character")
 m1.ids <- m1.cases[grep("TCGA", m1.cases)]
-m1.dat <- data.frame(patientid=m1.ids, subtype="Chromatin remodeling processes",cancertype="CLear cell renal")
+m1.dat <- data.frame(patientid=m1.ids, subtype="m1",cancertype="Clear cell renal")
 
 m2.cases <- scan("data/raw/cases_m2.txt",what="character")
 m2.ids <- m2.cases[grep("TCGA", m2.cases)]
-m2.dat <- data.frame(patientid=m2.ids, subtype="High expression of miR-21",cancertype="CLear cell renal")
+m2.dat <- data.frame(patientid=m2.ids, subtype="m2",cancertype="Clear cell renal")
 
 m3.cases <- scan("data/raw/cases_m3.txt",what="character")
 m3.ids <- m3.cases[grep("TCGA", m3.cases)]
-m3.dat <- data.frame(patientid=m3.ids, subtype="PTEN mutations and CDKN2A deletions",cancertype="CLear cell renal")
+m3.dat <- data.frame(patientid=m3.ids, subtype="m3",cancertype="Clear cell renal")
 
 m4.cases <- scan("data/raw/cases_m4.txt",what="character")
 m4.ids <- m4.cases[grep("TCGA", m4.cases)]
-m4.dat <- data.frame(patientid=m4.ids, subtype="BAP1 and mTOR mutations",cancertype="CLear cell renal")
+m4.dat <- data.frame(patientid=m4.ids, subtype="m4",cancertype="Clear cell renal")
 
 all_kirc <- rbind(m1.dat, m2.dat, m3.dat, m4.dat)
 all_kirc[order(all_kirc$patientid), ]

--- a/src/data/TCGA_ids_and_subtype_kirp.R
+++ b/src/data/TCGA_ids_and_subtype_kirp.R
@@ -1,14 +1,14 @@
 c1_kirp.cases <- scan("data/raw/cases_mRNA_cluster_1.txt",what="character")
 c1_kirp.ids <- c1_kirp.cases[grep("TCGA", c1_kirp.cases)]
-c1_kirp.dat <- data.frame(patientid=c1_kirp.ids, subtype="type I papillary and MET mutations",cancertype="Papillary renal")
+c1_kirp.dat <- data.frame(patientid=c1_kirp.ids, subtype="mRNA Cluster 1",cancertype="Papillary renal")
 
 c2_kirp.cases <- scan("data/raw/cases_mRNA_cluster_2.txt",what="character")
 c2_kirp.ids <- c2_kirp.cases[grep("TCGA", c2_kirp.cases)]
-c2_kirp.dat <- data.frame(patientid=c2_kirp.ids, subtype="Mostly type II papillary or unclassified",cancertype="Papillary renal")
+c2_kirp.dat <- data.frame(patientid=c2_kirp.ids, subtype="mRNA Cluster 2",cancertype="Papillary renal")
 
 c3_kirp.cases <- scan("data/raw/cases_mRNA_cluster_3.txt", what="character")
 c3_kirp.ids <- c3_kirp.cases[grep("TCGA", c3_kirp.cases)]
-c3_kirp.dat <- data.frame(patientid=c3_kirp.ids, subtype="Best survival",cancertype="Papillary renal")
+c3_kirp.dat <- data.frame(patientid=c3_kirp.ids, subtype="mRNA Cluster 3",cancertype="Papillary renal")
 
 all_kirp <-rbind(c1_kirp.dat, c2_kirp.dat, c3_kirp.dat)
 all_kirp_order <- all_kirp[order(all_kirp$patientid), ]


### PR DESCRIPTION
For 3 cancer types (glioma, kidney clear cell, and kidney papillary), I changed the subtypes.  The new subtypes match exactly what is found in the published literature.  This is because there may be a convention in the field where everyone knows a specific subtype (e.g. clinicians are familiar with LGr1 as a subtype of glioma vs most upregulate TERT as a subtype of glioma).